### PR TITLE
Allow setting more IPMI options per target

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,19 @@ rather than one exporter per IPMI device.
 
 The exporter requires a configuration file called `ipmi.yml` (can be
 overridden, see above). To collect local metrics, an empty file is technically
-sufficient.  For remote metrics, it must contain user names and passwords for
-IPMI access to all targets. It supports a “default” target, which is used as
-fallback if the target is not explicitly listed in the file.
+sufficient.  For remote metrics, it must contain at least user names and
+passwords for IPMI access to all targets to be scraped. You can additionally
+specify the IPMI driver type and privilege level to use (see `man 5
+freeipmi.conf` for more details and possible values).
+
+The config file supports a “default” target, settings for which are used as a
+fallback for anything not explicitly set for a given target.
 
 The configuration file also supports a blacklist of sensors, useful in case of
 OEM-specific sensors that FreeIPMI cannot deal with properly or otherwise
 misbehaving sensors. This applies to both local and remote metrics.
 
-See the included `ipmi.yml` file for an example.
+See the included `ipmi.yml` file for a commented example.
 
 ### Prometheus
 

--- a/config.go
+++ b/config.go
@@ -10,9 +10,15 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+const (
+	defaultDriver    = "LAN_2_0"
+	defaultPrivilege = "admin"
+)
+
 // Config is the Go representation of the yaml config file.
 type Config struct {
-	Credentials map[string]Credentials `yaml:"credentials"`
+	Targets    map[string]RMCPConfig  `yaml:"targets"`
+	Deprecated map[string]Credentials `yaml:"credentials"`
 
 	ExcludeSensorIDs []int64 `yaml:"exclude_sensor_ids"`
 
@@ -26,11 +32,17 @@ type SafeConfig struct {
 	C *Config
 }
 
-// Credentials is the Go representation of the credentials section in the yaml
+// Credentials is used temporarily to catch formerly valid configs and
+// point out that they should be changed. This will be removed eventually.
+type Credentials struct{}
+
+// RMCPConfig is the Go representation of a targets configuration in the yaml
 // config file.
-type Credentials struct {
-	User     string `yaml:"user"`
-	Password string `yaml:"pass"`
+type RMCPConfig struct {
+	User      string `yaml:"user"`
+	Password  string `yaml:"pass"`
+	Privilege string `yaml:"privilege"`
+	Driver    string `yaml:"driver"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
@@ -60,15 +72,23 @@ func (s *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *Credentials) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type plain Credentials
+func (s *RMCPConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain RMCPConfig
 	if err := unmarshal((*plain)(s)); err != nil {
 		return err
 	}
-	if err := checkOverflow(s.XXX, "credentials"); err != nil {
+	if err := checkOverflow(s.XXX, "targets"); err != nil {
 		return err
 	}
 	return nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (s *Credentials) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	log.Errorf("The 'credentials' section in the config file is no longer supported")
+	log.Errorf("Renaming the section to 'targets' will do, but it also supports additional features")
+	log.Errorf("Please check the latest documentation at https://github.com/soundcloud/ipmi_exporter")
+	return fmt.Errorf("The 'credentials' section in the config file is no longer supported")
 }
 
 // ReloadConfig reloads the config in a concurrency-safe way. If the configFile
@@ -83,7 +103,6 @@ func (sc *SafeConfig) ReloadConfig(configFile string) error {
 	}
 
 	if err := yaml.Unmarshal(yamlFile, c); err != nil {
-		log.Errorf("Error parsing config file: %s", err)
 		return err
 	}
 
@@ -95,24 +114,48 @@ func (sc *SafeConfig) ReloadConfig(configFile string) error {
 	return nil
 }
 
-// CredentialsForTarget returns the Credentials for a given target, or the
+// ConfigForTarget returns the config for a given target, or the
 // default. It is concurrency-safe.
-func (sc *SafeConfig) CredentialsForTarget(target string) (Credentials, error) {
+func (sc *SafeConfig) ConfigForTarget(target string) (RMCPConfig, error) {
 	sc.Lock()
 	defer sc.Unlock()
-	if credentials, ok := sc.C.Credentials[target]; ok {
-		return Credentials{
-			User:     credentials.User,
-			Password: credentials.Password,
-		}, nil
+
+	// Start with hardcoded defaults
+	config := RMCPConfig{
+		Driver:    defaultDriver,
+		Privilege: defaultPrivilege,
 	}
-	if credentials, ok := sc.C.Credentials["default"]; ok {
-		return Credentials{
-			User:     credentials.User,
-			Password: credentials.Password,
-		}, nil
+	// Apply config defaults if present
+	if defaultConfig, ok := sc.C.Targets["default"]; ok {
+		config.User = defaultConfig.User
+		config.Password = defaultConfig.Password
+		if defaultConfig.Driver != "" {
+			config.Driver = defaultConfig.Driver
+		}
+		if defaultConfig.Privilege != "" {
+			config.Privilege = defaultConfig.Privilege
+		}
 	}
-	return Credentials{}, fmt.Errorf("no credentials found for target %s", target)
+	// Apply target-specific values if present
+	if targetConfig, ok := sc.C.Targets[target]; ok {
+		if targetConfig.User != "" {
+			config.User = targetConfig.User
+		}
+		if targetConfig.Password != "" {
+			config.Password = targetConfig.Password
+		}
+		if targetConfig.Driver != "" {
+			config.Driver = targetConfig.Driver
+		}
+		if targetConfig.Privilege != "" {
+			config.Privilege = targetConfig.Privilege
+		}
+	}
+
+	if config.User == "" || config.Password == "" {
+		return RMCPConfig{}, fmt.Errorf("no credentials found for target %s", target)
+	}
+	return config, nil
 }
 
 // ExcludeSensorIDs returns the list of excluded sensor IDs in a

--- a/ipmi.yml
+++ b/ipmi.yml
@@ -1,11 +1,27 @@
-credentials:
+# Configuration file for ipmi_exporter
+
+# Information required to access remote IPMI interfaces can be supplied in the
+# 'targets' section.  Settings from the special target 'default' are used for
+# anything not specified for a target.
+targets:
         default:
+                # These settings would be used for any target other then those
+                # listed below, driver and privilege reflect the built-in
+                # defaults if not specified at all.
                 user: "default_user"
                 pass: "example_pw"
+                driver: "LAN_2_0"
+                privilege: "admin"
         10.8.0.2:
+                # Override settings for a specific target. Uses default driver.
                 user: "host_specific_user"
                 pass: "another_pw"
+                privilege: "user"
+        10.8.0.2:
+                # Uses everything from the default section, but LAN driver.
+                driver: "LAN"
 
+# List of sensor IDs to be excluded
 exclude_sensor_ids:
   - 2
   - 29
@@ -21,4 +37,4 @@ exclude_sensor_ids:
   - 85
   - 86
   - 87
-  
+


### PR DESCRIPTION
Specifically, allow setting the IPMI driver and privilege level. Can be
set both in the "default" target as well as overridden per target. The
example config has examples, see `man 5 freeipmi.conf` for more details
about these settings.

THIS COMMIT CHANGES THE CONFIG FORMAT IN A NON-BACKWARDS-COMPATIBLE WAY!

Even though compatibility would have been technically possible, the
semantics of the "credentials" section would not match the name anymore,
certainly leading to more confusion in the long run. Best to break
things as early as possible. At least there is a friendly hook in the
config parser telling you pretty precisely what to do.

This fixes #10 by allowing to set the default privilege level.

@grobie @beorn7 @SuperQ :eyes: :question: 