### PR TITLE
Add rmcp host to log messages

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -366,13 +366,13 @@ func collectGenericSensor(ch chan<- prometheus.Metric, state float64, data senso
 func (c collector) collectMonitoring(ch chan<- prometheus.Metric, rmcp *rmcpConfig) (int, error) {
 	output, err := ipmiMonitoringOutput(rmcp)
 	if err != nil {
-		log.Errorf("Failed to collect ipmimonitoring data: %s", err)
+		log.Errorf("Failed to collect ipmimonitoring data from %s: %s", rcmp.host, err)
 		return 0, err
 	}
 	excludeIds := c.config.ExcludeSensorIDs()
 	results, err := splitMonitoringOutput(output, excludeIds)
 	if err != nil {
-		log.Errorf("Failed to parse ipmimonitoring data: %s", err)
+		log.Errorf("Failed to parse ipmimonitoring data from %s: %s", rcmp.host, err)
 		return 0, err
 	}
 	for _, data := range results {
@@ -415,12 +415,12 @@ func (c collector) collectMonitoring(ch chan<- prometheus.Metric, rmcp *rmcpConf
 func (c collector) collectDCMI(ch chan<- prometheus.Metric, rmcp *rmcpConfig) (int, error) {
 	output, err := ipmiDCMIOutput(rmcp)
 	if err != nil {
-		log.Debugf("Failed to collect ipmi-dcmi data: %s", err)
+		log.Debugf("Failed to collect ipmi-dcmi data from %s: %s", rcmp.host, err)
 		return 0, err
 	}
 	currentPowerConsumption, err := getCurrentPowerConsumption(output)
 	if err != nil {
-		log.Errorf("Failed to parse ipmi-dcmi data: %s", err)
+		log.Errorf("Failed to parse ipmi-dcmi data from %s: %s", rcmp.host, err)
 		return 0, err
 	}
 	ch <- prometheus.MustNewConstMetric(
@@ -434,17 +434,17 @@ func (c collector) collectDCMI(ch chan<- prometheus.Metric, rmcp *rmcpConfig) (i
 func (c collector) collectBmcInfo(ch chan<- prometheus.Metric, rmcp *rmcpConfig) (int, error) {
 	output, err := bmcInfoOutput(rmcp)
 	if err != nil {
-		log.Debugf("Failed to collect bmc-info data: %s", err)
+		log.Debugf("Failed to collect bmc-info data from %s: %s", rcmp.host, err)
 		return 0, err
 	}
 	firmwareRevision, err := getBMCInfoFirmwareRevision(output)
 	if err != nil {
-		log.Errorf("Failed to parse bmc-info data: %s", err)
+		log.Errorf("Failed to parse bmc-info data from %s: %s", rcmp.host, err)
 		return 0, err
 	}
 	manufacturerID, err := getBMCInfoManufacturerID(output)
 	if err != nil {
-		log.Errorf("Failed to parse bmc-info data: %s", err)
+		log.Errorf("Failed to parse bmc-info data from %s: %s", rcmp.host, err)
 		return 0, err
 	}
 	ch <- prometheus.MustNewConstMetric(

--- a/collector.go
+++ b/collector.go
@@ -224,7 +224,7 @@ func freeipmiOutput(cmd string, rmcp *rmcpConfig, arg ...string) ([]byte, error)
 	args = append(args, arg...)
 	out, err := exec.Command(fqcmd, args...).CombinedOutput()
 	if err != nil {
-		log.Errorf("Error while calling %s: %s", cmd, out)
+		log.Errorf("Error while calling %s for %s: %s", cmd, rmcp.host, out)
 	}
 	return out, err
 }

--- a/collector.go
+++ b/collector.go
@@ -366,13 +366,13 @@ func collectGenericSensor(ch chan<- prometheus.Metric, state float64, data senso
 func (c collector) collectMonitoring(ch chan<- prometheus.Metric, rmcp *rmcpConfig) (int, error) {
 	output, err := ipmiMonitoringOutput(rmcp)
 	if err != nil {
-		log.Errorf("Failed to collect ipmimonitoring data from %s: %s", rcmp.host, err)
+		log.Errorf("Failed to collect ipmimonitoring data from %s: %s", rmcp.host, err)
 		return 0, err
 	}
 	excludeIds := c.config.ExcludeSensorIDs()
 	results, err := splitMonitoringOutput(output, excludeIds)
 	if err != nil {
-		log.Errorf("Failed to parse ipmimonitoring data from %s: %s", rcmp.host, err)
+		log.Errorf("Failed to parse ipmimonitoring data from %s: %s", rmcp.host, err)
 		return 0, err
 	}
 	for _, data := range results {
@@ -415,12 +415,12 @@ func (c collector) collectMonitoring(ch chan<- prometheus.Metric, rmcp *rmcpConf
 func (c collector) collectDCMI(ch chan<- prometheus.Metric, rmcp *rmcpConfig) (int, error) {
 	output, err := ipmiDCMIOutput(rmcp)
 	if err != nil {
-		log.Debugf("Failed to collect ipmi-dcmi data from %s: %s", rcmp.host, err)
+		log.Debugf("Failed to collect ipmi-dcmi data from %s: %s", rmcp.host, err)
 		return 0, err
 	}
 	currentPowerConsumption, err := getCurrentPowerConsumption(output)
 	if err != nil {
-		log.Errorf("Failed to parse ipmi-dcmi data from %s: %s", rcmp.host, err)
+		log.Errorf("Failed to parse ipmi-dcmi data from %s: %s", rmcp.host, err)
 		return 0, err
 	}
 	ch <- prometheus.MustNewConstMetric(
@@ -434,17 +434,17 @@ func (c collector) collectDCMI(ch chan<- prometheus.Metric, rmcp *rmcpConfig) (i
 func (c collector) collectBmcInfo(ch chan<- prometheus.Metric, rmcp *rmcpConfig) (int, error) {
 	output, err := bmcInfoOutput(rmcp)
 	if err != nil {
-		log.Debugf("Failed to collect bmc-info data from %s: %s", rcmp.host, err)
+		log.Debugf("Failed to collect bmc-info data from %s: %s", rmcp.host, err)
 		return 0, err
 	}
 	firmwareRevision, err := getBMCInfoFirmwareRevision(output)
 	if err != nil {
-		log.Errorf("Failed to parse bmc-info data from %s: %s", rcmp.host, err)
+		log.Errorf("Failed to parse bmc-info data from %s: %s", rmcp.host, err)
 		return 0, err
 	}
 	manufacturerID, err := getBMCInfoManufacturerID(output)
 	if err != nil {
-		log.Errorf("Failed to parse bmc-info data from %s: %s", rcmp.host, err)
+		log.Errorf("Failed to parse bmc-info data from %s: %s", rmcp.host, err)
 		return 0, err
 	}
 	ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Thanks for sharing this awesome tool!

We are using it mostly for getting remote ipmi metrics via RMCP, and found it a bit tricky to correlate some errors to the actual target that is failing.

Hope you'll find this small PR useful, helped us fixed some issues with our hosts.