### PR TITLE
Allow setting the session timeout

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -187,6 +187,10 @@ func freeipmiConfig(config IPMIConfig) string {
 	if config.Password != "" {
 		fmt.Fprintf(&b, "password %s\n", config.Password)
 	}
+	if config.Timeout != 0 {
+		fmt.Fprintf(&b, "session-timeout %d\n", config.Timeout)
+	}
+	fmt.Println(b.String())
 	return b.String()
 }
 

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ type IPMIConfig struct {
 	Password         string   `yaml:"pass"`
 	Privilege        string   `yaml:"privilege"`
 	Driver           string   `yaml:"driver"`
+	Timeout          uint32   `yaml:"timeout"`
 	Collectors       []string `yaml:"collectors"`
 	ExcludeSensorIDs []int64  `yaml:"exclude_sensor_ids"`
 

--- a/ipmi_remote.yml
+++ b/ipmi_remote.yml
@@ -12,8 +12,14 @@ modules:
                 # module=default is specified.
                 user: "default_user"
                 pass: "example_pw"
+                # The below settings correspond to driver-type, privilege-level, and
+                # session-timeout respectively, see `man 5 freeipmi.conf`.
                 driver: "LAN_2_0"
                 privilege: "user"
+                # The session timeout is in milliseconds. Note that a scrape can take up
+                # to (session-timeout * #-of-collectors) milliseconds, so set the scrape
+                # timeout in Prometheus accordingly.
+                timeout: 10000
                 # Available collectors are bmc, ipmi, and dcmi
                 # If not specified, all three are used
                 collectors:


### PR DESCRIPTION
Now that we have a good config framework in place, this is low-hanging
fruit. Will apply to all collectors used, so total scrape time for
Prometheus could be (timeout * #-of-collectors) milliseconds for a given
module.

Related to #20.