### PR TITLE
No sensor state for PSU sensor on old BMC's 

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -237,7 +237,7 @@ func freeipmiOutput(cmd string, target ipmiTarget, arg ...string) ([]byte, error
 }
 
 func ipmiMonitoringOutput(target ipmiTarget) ([]byte, error) {
-	return freeipmiOutput("ipmimonitoring", target, "-Q", "--comma-separated-output", "--no-header-output", "--sdr-cache-recreate")
+	return freeipmiOutput("ipmimonitoring", target, "-Q", "--ignore-unrecognized-events", "--comma-separated-output", "--no-header-output", "--sdr-cache-recreate")
 }
 
 func ipmiDCMIOutput(target ipmiTarget) ([]byte, error) {


### PR DESCRIPTION
Hi,
while i was testing this exporter
if i run this command on one host
./ipmimonitoring -Q -b --comma-separated-output --output-sensor-state
the result would be
...... 32,PS Status,Power Supply,Nominal,N/A,N/A,'OK'
and Ipmi exporter will report
ipmi_sensor_state{id="32",name="PS Status",type="Power Supply"} 0
which is totally fine and correct
however on some old BMC's running the command :
./ipmimonitoring -Q -b --comma-separated-output --output-sensor-state
will give
1813,PS Status,Power Supply,N/A,N/A,N/A,'Presence detected' 'Unrecognized Event = 0100h' 'Unrecognized Event = 0200h' 'Unrecognized Event = 0400h' 'Unrecognized Event = 0800h' 'Unrecognized Event = 1000h' 'Unrecognized Event = 2000h' 'Unrecognized Event = 4000h'
and thus ipmi exporter will report
ipmi_sensor_value{id="1813",name="PS Status",type="Power Supply"} NaN
in this case the Presence detected in the event column tells that PSU plugged in and works
my goal is to monitor PSU's and write alerting rules for them
could you please check also the event column
somthing like :
_collector.go #396:_

              case "N/A":
			log.Debugf("Sensor reading is N/A checking event")
			if strings.Contains(data.Event, "Presence detected") || strings.Contains(data.Event, "OK") {
				log.Debugf("Event has 'Presence detected' or 'OK' setting to nominal")
				state = 0
			} else {
				state = math.NaN()
			}

i will submit a merge request soon
Thanks in advance