### PR TITLE
Ipmi-chassis power on/off state

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,13 @@ returned from the BMC. Example:
 
     ipmi_bmc_info{firmware_revision="2.52",manufacturer_id="Dell Inc. (674)"} 1
 
+### Chassis Power State
+This metric is only provided if the `chassis` collector is enabled.
+
+The metric `ipmi_chassis_power_state` shows the current chassis power state of the machine.
+The value is 1 for poweron, and 0 otherwise.
+
+
 ### Power consumption
 
 This metric is only provided if the `dcmi` collector is enabled.

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ type IPMIConfig struct {
 	XXX map[string]interface{} `yaml:",inline"`
 }
 
-var emptyConfig = IPMIConfig{Collectors: []string{"ipmi", "dcmi", "bmc"}}
+var emptyConfig = IPMIConfig{Collectors: []string{"ipmi", "dcmi", "bmc", "chassis"}}
 
 // CollectorName is used for unmarshaling the list of collectors in the yaml config file
 type CollectorName string
@@ -78,7 +78,7 @@ func (s *IPMIConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	for _, c := range s.Collectors {
-		if !(c == "ipmi" || c == "dcmi" || c == "bmc") {
+		if !(c == "ipmi" || c == "dcmi" || c == "bmc" || c == "chassis") {
 			return fmt.Errorf("unknown collector name: %s", c)
 		}
 	}

--- a/ipmi_local.yml
+++ b/ipmi_local.yml
@@ -4,11 +4,12 @@
 # In most cases, this should work without using a config file at all.
 modules:
         default:
-                # Available collectors are bmc, ipmi, and dcmi
+                # Available collectors are bmc, ipmi, chassis, and dcmi
                 collectors:
                 - bmc
                 - ipmi
                 - dcmi
+                - chassis
                 # Got any sensors you don't care about? Add them here.
                 exclude_sensor_ids:
                 - 2

--- a/ipmi_remote.yml
+++ b/ipmi_remote.yml
@@ -21,11 +21,12 @@ modules:
                 # to (session-timeout * #-of-collectors) milliseconds, so set the scrape
                 # timeout in Prometheus accordingly.
                 timeout: 10000
-                # Available collectors are bmc, ipmi, and dcmi
+                # Available collectors are bmc, ipmi, chassis, and dcmi
                 # If not specified, all three are used
                 collectors:
                 - bmc
                 - ipmi
+                - chassis
                 # Got any sensors you don't care about? Add them here.
                 exclude_sensor_ids:
                 - 2


### PR DESCRIPTION
I found that I had the need to track which machines were in the poweron / off state.
To do so, I extended ipmi_exporter to use the ipmi-chassis module
The new metric added is ipmi_chassis_power_state

The ipmi-chassis utility does export more results, but so far this is the only one I needed.
I thought this may be useful for others.