### PR TITLE
Added Dockerfile and example docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Build /go/bin/ipmi_exporter
+FROM golang:latest AS builder
+
+RUN go get github.com/soundcloud/ipmi_exporter \
+ && cd /go/src/github.com/soundcloud/ipmi_exporter \
+ && go build
+
+
+# Container image
+FROM ubuntu:18.04
+
+LABEL maintainer="Aggelos Kolaitis <neoaggelos@gmail.com>"
+
+WORKDIR /
+
+RUN apt-get update \
+    && apt-get install freeipmi-tools -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /go/bin/ipmi_exporter /ipmi_exporter
+
+EXPOSE 9290
+
+CMD ["/ipmi_exporter", "--config.file", "/config.yml"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ implementation.
 
 ## Installation
 
-You need a Go development environment. Then, run the following to get the 
+You need a Go development environment. Then, run the following to get the
 source code and build and install the binary:
 
     go get github.com/soundcloud/ipmi_exporter
@@ -66,6 +66,18 @@ When running this exporter as non root, you should do the followings.
       ````
   4. execute ipmi-exporter with the option
       `--freeipmi.path=/home/ipmi-exporter`
+
+### Running with docker (NOTE: remote metrics only)
+
+The root folder contains a `Dockerfile` and an example `docker-compose.yml`.
+Edit the `ipmi_remote.yml` file to configure IPMI credentials, then run with:
+
+```
+$ sudo docker-compose up -d
+```
+
+By default, the server will bind on `0.0.0.0:9290`.
+
 
 ## Configuration
 
@@ -323,4 +335,3 @@ type is added as label (in addition to name and ID). Example:
 
     ipmi_sensor_state{id="139",name="Power Cable",type="Cable/Interconnect"} 0
     ipmi_sensor_value{id="139",name="Power Cable",type="Cable/Interconnect"} NaN
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+services:
+  ipmi_exporter:
+    build:
+      context: .
+    volumes:
+      - ./ipmi_remote.yml:/config.yml:ro    # replace with your own config
+    ports:
+      - 9290:9290                           # bind on 0.0.0.0
+      # - 127.0.0.1:9290:9290               # or bind to specific interface
+    hostname: ipmi_exporter_docker


### PR DESCRIPTION
Added Dockerfile for ipmi_exporter, along with a simple docker-compose.yml. README.md has also been updated with instructions for getting ipmi_exporter up and running with docker-compose.