### PR TITLE
Adding config options for workaround_flags.

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -198,6 +198,13 @@ func freeipmiConfig(config IPMIConfig) string {
 	if config.Timeout != 0 {
 		fmt.Fprintf(&b, "session-timeout %d\n", config.Timeout)
 	}
+	if len(config.WorkaroundFlags) > 0 {
+		fmt.Fprintf(&b, "workaround-flags")
+		for _, flag := range config.WorkaroundFlags {
+			fmt.Fprintf(&b, " %s", flag)
+		}
+		fmt.Fprintln(&b)
+	}
 	return b.String()
 }
 

--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ type IPMIConfig struct {
 	Timeout          uint32   `yaml:"timeout"`
 	Collectors       []string `yaml:"collectors"`
 	ExcludeSensorIDs []int64  `yaml:"exclude_sensor_ids"`
+	WorkaroundFlags  []string `yaml:"workaround_flags"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/ipmi_remote.yml
+++ b/ipmi_remote.yml
@@ -44,10 +44,17 @@ modules:
                 collectors:
                 - dcmi
         thatspecialhost:
-                #  Use these settings when scraped with module=thatspecialhost.
+                # Use these settings when scraped with module=thatspecialhost.
                 user: "some_user"
                 pass: "secret_pw"
                 privilege: "admin"
                 driver: "LAN"
                 collectors:
                 - ipmi
+                # Need any special workaround flags set? Add them here.
+                # Workaround flags might be needed to address issues with specific vendor implementations
+                # e.g. https://www.gnu.org/software/freeipmi/freeipmi-faq.html#Why-is-the-output-from-FreeIPMI-different-than-another-software_003f
+                # For a full list of flags, refer to:
+                # https://www.gnu.org/software/freeipmi/manpages/man8/ipmi-sensors.8.html#lbAL
+                workaround_flags:
+                - discretereading


### PR DESCRIPTION
Provides a way to specify in the config file `workaround_flags` to be passed onto FreeIPMI.

I needed this to pass in a flag due to a known issue with HP ProLiant servers:
tps://www.gnu.org/software/freeipmi/freeipmi-faq.html#Why-is-the-output-from-FreeIPMI-different-than-another-software_003f

Thought this might be of interest to others as well for different workaround flags needed for their systems.