### PR TITLE
Fixed #59

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build /go/bin/ipmi_exporter
-FROM quay.io/prometheus/golang-builder:1.13-base AS builder
+FROM quay.io/prometheus/golang-builder:1.15-base AS builder
 ADD . /go/src/github.com/soundcloud/ipmi_exporter/
 RUN cd /go/src/github.com/soundcloud/ipmi_exporter && make
 
@@ -10,7 +10,7 @@ RUN apt-get update \
     && apt-get install freeipmi-tools -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /go/src/github.com/soundcloud/ipmi_exporter/ipmi_exporter /bin/ipmi_exporter
+COPY --from=builder /go/src/github.com/soundcloud/ipmi_exporter/ipmi-exporter /bin/ipmi_exporter
 
 EXPOSE 9290
 ENTRYPOINT ["/bin/ipmi_exporter"]


### PR DESCRIPTION
The issue needs to change only "ipmi-exporter", but I think it is better for updating golang-builder version.