### PR TITLE
Add a `bmc-device-id` collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,14 @@ These metrics provide data about the scrape itself:
 
 ### BMC info
 
-This metric is only provided if the `bmc` collector is enabled.
+This metric is only provided if the `bmc` or `bmc-device-id` collector is
+enabled.
+
+**Note:** you can only use either the `bmc` or the `bmc-device-id` collector,
+not both. The `bmc` collector attempts to make the system firmware revision
+available, which breaks work on some older systems. In this case, the
+`bmc-device-id` collector can be used, but the system firmware revision will
+always be `"N/A"`.
 
 For some basic information, there is a constant metric `ipmi_bmc_info` with
 value `1` and labels providing the firmware revision and manufacturer as
@@ -294,8 +301,8 @@ version). Example:
 
     ipmi_bmc_info{firmware_revision="1.66",manufacturer_id="Dell Inc. (674)",system_firmware_version="2.6.1"} 1
 
-**Note:** some systems do not expose the system's firmware version, in which
-case it will be exported as `"N/A"`.
+**Note:** some systems do not expose the system's firmware version, even if the
+`bmc` collector works. In this case it will be exported as `"N/A"`.
 
 ### Chassis Power State
 

--- a/config.go
+++ b/config.go
@@ -40,7 +40,7 @@ type IPMIConfig struct {
 	XXX map[string]interface{} `yaml:",inline"`
 }
 
-var emptyConfig = IPMIConfig{Collectors: []string{"ipmi", "dcmi", "bmc", "chassis"}}
+var emptyConfig = IPMIConfig{Collectors: []string{"ipmi", "dcmi", "bmc", "bmc-device-id", "chassis"}}
 
 // CollectorName is used for unmarshaling the list of collectors in the yaml config file
 type CollectorName string
@@ -78,9 +78,19 @@ func (s *IPMIConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := checkOverflow(s.XXX, "modules"); err != nil {
 		return err
 	}
+
+	usesBmc := false
 	for _, c := range s.Collectors {
-		if !(c == "ipmi" || c == "sm-lan-mode" || c == "dcmi" || c == "bmc" || c == "chassis" || c == "sel") {
+		if !(c == "ipmi" || c == "sm-lan-mode" || c == "dcmi" || c == "bmc" || c == "bmc-device-id" || c == "chassis" || c == "sel") {
 			return fmt.Errorf("unknown collector name: %s", c)
+		}
+
+		if c == "bmc" || c == "bmc-device-id" {
+			if !usesBmc {
+				usesBmc = true
+			} else {
+				return fmt.Errorf("cannot use 'bmc' and 'bmc-device-id' collectors at the same time")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
When the `bmc` collector was extended to attempt to collect the system
firmware revision the resulting IPMI request broke on some older
systems. This collector can be used as a fallback for these systems. For
obvious reasons, the `bmc` and `bmc-device-id` collectors cannot be used
at the same time, which is checked at config load time.

This should finally fix #57.