### PR TITLE
Failed COPY ipmi_exporter from=builder - again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build /go/bin/ipmi_exporter
-FROM quay.io/prometheus/golang-builder:latest AS builder
+FROM quay.io/prometheus/golang-builder:1.15-base AS builder
 ADD . /go/src/github.com/soundcloud/ipmi_exporter/
 RUN cd /go/src/github.com/soundcloud/ipmi_exporter && make
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build /go/bin/ipmi_exporter
-FROM quay.io/prometheus/golang-builder:1.15-base AS builder
+FROM quay.io/prometheus/golang-builder:latest AS builder
 ADD . /go/src/github.com/soundcloud/ipmi_exporter/
 RUN cd /go/src/github.com/soundcloud/ipmi_exporter && make
 
@@ -10,7 +10,7 @@ RUN apt-get update \
     && apt-get install freeipmi-tools -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /go/src/github.com/soundcloud/ipmi_exporter/ipmi-exporter /bin/ipmi_exporter
+COPY --from=builder /go/src/github.com/soundcloud/ipmi_exporter/ipmi_exporter /bin/ipmi_exporter
 
 EXPOSE 9290
 ENTRYPOINT ["/bin/ipmi_exporter"]


### PR DESCRIPTION
Sorry about the previous Issue #59,
It seems the docker's bug or something, and it has already fixed.

So, could you update the DockerFile again please ?

##### ISSUE TYPE

 - Bug

##### HOW TO GET THE INFO

docker build . 
(or make docker)
 
##### SAMPLE COMMAND OUTPUT

https://github.com/soundcloud/ipmi_exporter/issues/59#issuecomment-781759774

##### CAUSE

go builder in docker makes ipmi_exporter as `ipmi_exporter` again.

```
>> running check for unused packages in vendor/
GO111MODULE=on go mod vendor
curl -s -L https://github.com/prometheus/promu/releases/download/v0.5.0/promu-0.5.0.linux-amd64.tar.gz | tar -xvzf - -C /tmp/tmp.3HO4rjwbn0
promu-0.5.0.linux-amd64/
promu-0.5.0.linux-amd64/promu
promu-0.5.0.linux-amd64/NOTICE
promu-0.5.0.linux-amd64/LICENSE
mkdir -p /go/bin
cp /tmp/tmp.3HO4rjwbn0/promu-0.5.0.linux-amd64/promu /go/bin/promu
rm -r /tmp/tmp.3HO4rjwbn0
>> building binaries
GO111MODULE=on /go/bin/promu build --prefix /go/src/github.com/soundcloud/ipmi_exporter 
 >   ipmi_exporter
>> running all tests
```

### SOLUTION

Change filename.

https://github.com/soundcloud/ipmi_exporter/issues/59#issuecomment-781759774
