### PR TITLE
add --bridge-sensors as a default parameter.

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -281,7 +281,7 @@ func freeipmiOutput(cmd string, target ipmiTarget, arg ...string) ([]byte, error
 }
 
 func ipmiMonitoringOutput(target ipmiTarget) ([]byte, error) {
-	return freeipmiOutput("ipmimonitoring", target, "-Q", "--ignore-unrecognized-events", "--comma-separated-output", "--no-header-output", "--sdr-cache-recreate", "--output-event-bitmask")
+	return freeipmiOutput("ipmimonitoring", target, "-Q", "--ignore-unrecognized-events", "--comma-separated-output", "--no-header-output", "--sdr-cache-recreate", "--output-event-bitmask", "--bridge-sensors")
 }
 
 func ipmiDCMIOutput(target ipmiTarget) ([]byte, error) {


### PR DESCRIPTION
Fix many issues fetching sensors on recent HP servers.
Tested extensively on HP iLO5.

issue: https://github.com/soundcloud/ipmi_exporter/issues/54